### PR TITLE
Ensure minimized windows are not set to "onTop" so that restoration will succeed on macOS

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,13 @@ function setActive(newState) {
   isActive = newState;
   if (app_) {
     debug('setActive on windows', newState);
-    app_.getWindows().forEach(win => win.setAlwaysOnTop(isActive));
+    app_.getWindows().forEach(win => {
+      if (!win.isMinimized()) {
+        win.once('minimize', win.setAlwaysOnTop(false));
+        win.setAlwaysOnTop(isActive);
+      }
+      win.once('restore', win.setAlwaysOnTop(isActive));
+    });
   }
 }
 


### PR DESCRIPTION
Ensure minimized windows are not set to "onTop" so that restoration will succeed on macOS

#5 